### PR TITLE
Remove st2mistral from check if community st2 is installed

### DIFF
--- a/scripts/bwc-installer.sh
+++ b/scripts/bwc-installer.sh
@@ -208,7 +208,7 @@ else
 fi
 
 
-if ${PKG_TYPE}_is_installed st2 st2mistral; then
+if ${PKG_TYPE}_is_installed st2; then
     echo 'StackStorm Community version is already installed.'
     echo 'Proceeding with Enterprise install ...'
 elif ! curl --output /dev/null --silent --fail ${ST2_COMMUNITY_INSTALLER}; then


### PR DESCRIPTION
Remove st2mistral as a requirement for the check if the community version of st2 is installed.