### PR TITLE
Remove support for Ubuntu 14.04 (Trusty)

### DIFF
--- a/scripts/bwc-installer.sh
+++ b/scripts/bwc-installer.sh
@@ -196,8 +196,8 @@ elif [[ -n "$DEBTEST" ]]; then
   echo "*** Detected Distro is ${DEBTEST} ***"
   SUBTYPE=`lsb_release -a 2>&1 | grep Codename | grep -v "LSB" | awk '{print $2}'`
   echo "*** Detected flavor ${SUBTYPE} ***"
-  if [[ "$SUBTYPE" != 'trusty' && "$SUBTYPE" != 'xenial' && "$SUBTYPE" != 'bionic' ]]; then
-    echo "Unsupported ubuntu flavor ${SUBTYPE}. Please use 14.04 (trusty), 16.04 (xenial) or 18.04 (bionic) as base system!"
+  if [[ "$SUBTYPE" != 'xenial' && "$SUBTYPE" != 'bionic' ]]; then
+    echo "Unsupported ubuntu flavor ${SUBTYPE}. Please use 16.04 (xenial) or 18.04 (bionic) as base system!"
     exit 2
   fi
   BWC_OS_INSTALLER="${BASE_PATH}/${BRANCH}/scripts/bwc-installer-deb.sh"


### PR DESCRIPTION
Ubuntu 14.04 (aka Trusty) is no longer supported on EWC v3.2